### PR TITLE
Refactor fetching logic

### DIFF
--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import { useTheme } from "../lib/hooks/useTheme";
+
+const ErrorPage = () => {
+  const theme = useTheme();
+
+  const onlineLogoSrc =
+    theme === "dark" ? "/Online_hvit.svg" : "/Online_bla.svg";
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-10 bg-white dark:bg-gray-900">
+      <Image
+        src={onlineLogoSrc}
+        width={300}
+        height={100}
+        alt="Online logo"
+      />
+      <div className="text-xl text-black dark:text-white">Det har skjedd en feil :(</div>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/components/applicantoverview/ApplicantsOverview.tsx
+++ b/components/applicantoverview/ApplicantsOverview.tsx
@@ -10,8 +10,8 @@ import ApplicantTable from "./ApplicantTable";
 import ApplicantOverviewSkeleton from "./ApplicantOverviewSkeleton";
 
 interface Props {
-  period: periodType | null;
-  committees?: string[] | null;
+  period?: periodType;
+  committees?: string[];
   committee?: string;
   includePreferences: boolean;
 }

--- a/components/applicantoverview/ApplicantsOverview.tsx
+++ b/components/applicantoverview/ApplicantsOverview.tsx
@@ -10,8 +10,8 @@ import ApplicantTable from "./ApplicantTable";
 import ApplicantOverviewSkeleton from "./ApplicantOverviewSkeleton";
 
 interface Props {
-  period?: periodType;
-  committees?: string[];
+  period?: periodType | null;
+  committees?: string[] | null;
   committee?: string;
   includePreferences: boolean;
 }

--- a/lib/api/applicantApi.ts
+++ b/lib/api/applicantApi.ts
@@ -1,0 +1,9 @@
+import { QueryFunctionContext } from '@tanstack/react-query';
+
+export const fetchApplicantByPeriodAndId = async (context: QueryFunctionContext) => {
+  const periodId = context.queryKey[1];
+  const applicantId = context.queryKey[2];
+  return fetch(`/api/applicants/${periodId}/${applicantId}`).then(res =>
+    res.json()
+  );
+}

--- a/lib/api/periodApi.ts
+++ b/lib/api/periodApi.ts
@@ -1,0 +1,8 @@
+import { QueryFunctionContext } from '@tanstack/react-query';
+
+export const fetchPeriodById = async (context: QueryFunctionContext) => {
+  const id = context.queryKey[1];
+  return fetch(`/api/periods/${id}`).then(res =>
+    res.json()
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@heroicons/react": "^2.1.3",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "github:tailwindcss/typography",
+        "@tanstack/react-query": "^5.51.11",
         "@types/mongodb": "^4.0.7",
         "mongodb": "^6.1.0",
         "next": "^12.3.4",
@@ -1732,6 +1733,30 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.51.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.51.9.tgz",
+      "integrity": "sha512-HsAwaY5J19MD18ykZDS3aVVh+bAt0i7m6uQlFC2b77DLV9djo+xEN7MWQAQQTR8IM+7r/zbozTQ7P0xr0bHuew==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.51.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.51.11.tgz",
+      "integrity": "sha512-4Kq2x0XpDlpvSnaLG+8pHNH60zEc3mBvb3B2tOMDjcPCi/o+Du3p/9qpPLwJOTliVxxPJAP27fuIhLrsRdCr7A==",
+      "dependencies": {
+        "@tanstack/query-core": "5.51.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@types/json5": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@heroicons/react": "^2.1.3",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "github:tailwindcss/typography",
+    "@tanstack/react-query": "^5.51.11",
     "@types/mongodb": "^4.0.7",
     "mongodb": "^6.1.0",
     "next": "^12.3.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,15 @@ import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import LoadingPage from "../components/LoadingPage";
 import Signature from "../lib/utils/Signature";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: { // TODO: go over default options
+    queries: {
+      staleTime: 1000 * 60 * 10,
+    },
+  },
+});
 
 const SessionHandler: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -70,12 +79,14 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: any) {
       </Head>
       <div className="flex flex-col min-h-screen bg-white dark:text-white dark:bg-gray-900">
         <SessionHandler>
-          <Toaster />
-          <Navbar />
-          <div className="flex-grow">
-            <Component {...pageProps} />
-          </div>
-          <Footer />
+          <QueryClientProvider client={queryClient}>
+            <Toaster />
+            <Navbar />
+            <div className="flex-grow">
+              <Component {...pageProps} />
+            </div>
+            <Footer />
+          </QueryClientProvider>
         </SessionHandler>
       </div>
     </SessionProvider>

--- a/pages/admin/[period-id]/index.tsx
+++ b/pages/admin/[period-id]/index.tsx
@@ -1,44 +1,34 @@
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import router from "next/router";
-import { applicantType, periodType } from "../../../lib/types/types";
+import { periodType } from "../../../lib/types/types";
 import NotFound from "../../404";
 import ApplicantsOverview from "../../../components/applicantoverview/ApplicantsOverview";
+import { useQuery } from '@tanstack/react-query';
+import { fetchPeriodById } from "../../../lib/api/periodApi";
+import LoadingPage from "../../../components/LoadingPage";
+import ErrorPage from "../../../components/ErrorPage";
 
 const Admin = () => {
   const { data: session } = useSession();
   const periodId = router.query["period-id"];
-  const [period, setPeriod] = useState<periodType | null>(null);
-  const [committees, setCommittees] = useState<string[] | null>(null);
+
+  const [period, setPeriod] = useState<periodType>();
+  const [committees, setCommittees] = useState<string[]>();
+
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['periods', periodId],
+    queryFn: fetchPeriodById,
+  });
 
   useEffect(() => {
-    const fetchPeriod = async () => {
-      if (!session || session.user?.role !== "admin") {
-        return;
-      }
-      if (periodId === undefined) return;
+    setPeriod(data?.period)
+    setCommittees(data?.period.committees)
+  }, [data, session?.user?.owId]);
 
-      try {
-        const response = await fetch(`/api/periods/${periodId}`);
-        const data = await response.json();
-        if (response.ok) {
-          setPeriod(data.period);
-          setCommittees(data.period.committees);
-        } else {
-          throw new Error(data.error || "Unknown error");
-        }
-      } catch (error) {
-        console.error("Error checking period:", error);
-      } finally {
-      }
-    };
-
-    fetchPeriod();
-  }, [session?.user?.owId, periodId]);
-
-  if (!session || session.user?.role !== "admin") {
-    return <NotFound />;
-  }
+  if (!session || session.user?.role !== "admin") return <NotFound />;
+  if (isLoading) return <LoadingPage />;
+  if (isError) return <ErrorPage />;
 
   return (
     <ApplicantsOverview

--- a/pages/admin/[period-id]/index.tsx
+++ b/pages/admin/[period-id]/index.tsx
@@ -13,8 +13,8 @@ const Admin = () => {
   const { data: session } = useSession();
   const periodId = router.query["period-id"];
 
-  const [period, setPeriod] = useState<periodType>();
-  const [committees, setCommittees] = useState<string[]>();
+  const [period, setPeriod] = useState<periodType | null>(null);
+  const [committees, setCommittees] = useState<string[] | null>(null);
 
   const { data, isError, isLoading } = useQuery({
     queryKey: ['periods', periodId],

--- a/pages/admin/[period-id]/index.tsx
+++ b/pages/admin/[period-id]/index.tsx
@@ -26,7 +26,7 @@ const Admin = () => {
     setCommittees(data?.period.committees)
   }, [data, session?.user?.owId]);
 
-  if (!session || session.user?.role !== "admin") return <NotFound />;
+  if (session?.user?.role !== "admin") return <NotFound />;
   if (isLoading) return <LoadingPage />;
   if (isError) return <ErrorPage />;
 

--- a/pages/committee/[period-id]/[committee]/index.tsx
+++ b/pages/committee/[period-id]/[committee]/index.tsx
@@ -20,6 +20,9 @@ import { changeDisplayName } from "../../../../lib/utils/toString";
 import Custom404 from "../../../404";
 import PageTitle from "../../../../components/PageTitle";
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { fetchPeriodById } from "../../../../lib/api/periodApi";
+import ErrorPage from "../../../../components/ErrorPage";
 
 const CommitteeApplicantOverView: NextPage = () => {
   const { data: session } = useSession();
@@ -38,21 +41,14 @@ const CommitteeApplicantOverView: NextPage = () => {
 
   const [singleCommitteeInPeriod, setSingleCommitteeInPeriod] = useState<boolean>(true);
 
+  const { data: periodData, isError: periodIsError, isLoading: periodIsLoading } = useQuery({
+    queryKey: ['periods', periodId],
+    queryFn: fetchPeriodById,
+  });
+
   useEffect(() => {
-    if (!session || !periodId) return;
-
-    const fetchPeriod = async () => {
-      try {
-        const res = await fetch(`/api/periods/${periodId}`);
-        const data = await res.json();
-        setPeriod(data.period);
-      } catch (error) {
-        console.error("Failed to fetch interview periods:", error);
-      }
-    };
-
-    fetchPeriod();
-  }, [periodId]);
+    setPeriod(periodData?.period);
+  }, [periodData]);
 
   useEffect(() => {
     const userCommittees = session?.user?.committees?.map(c => c.toLowerCase()) || [];
@@ -120,13 +116,9 @@ const CommitteeApplicantOverView: NextPage = () => {
     checkAccess();
   }, [period]);
 
-  if (loading) {
-    return <LoadingPage />;
-  }
-
-  if (!session || !hasAccess) {
-    return <Custom404 />;
-  }
+  if (loading || periodIsLoading) return <LoadingPage />;
+  if (!hasAccess) return <Custom404 />;
+  if (periodIsError) return <ErrorPage />;
 
   const interviewPeriodEnd = period?.interviewPeriod.end
     ? new Date(period.interviewPeriod.end)

--- a/pages/committee/[period-id]/index.tsx
+++ b/pages/committee/[period-id]/index.tsx
@@ -3,51 +3,43 @@ import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import LoadingPage from "../../../components/LoadingPage";
 import CommitteeCard from "../../../components/committee/CommitteeCard";
+import { useQuery } from "@tanstack/react-query";
+import { fetchPeriodById } from "../../../lib/api/periodApi";
+import ErrorPage from "../../../components/ErrorPage";
+import NotFound from "../../404";
 
 const ChooseCommittee = () => {
   const { data: session } = useSession();
   const router = useRouter();
   const periodId = router.query["period-id"];
-  const [committees, setCommittees] = useState<string[] | null>(null);
-  const [loading, setLoading] = useState(true);
+
+  const [committees, setCommittees] = useState<string[]>();
+
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['periods', periodId],
+    queryFn: fetchPeriodById,
+  });
 
   useEffect(() => {
-    const fetchPeriod = async () => {
-      if (!session || !periodId) return;
+    if(!data) return;
 
-      try {
-        const res = await fetch(`/api/periods/${periodId}`);
-        const data = await res.json();
+    const userCommittees = session!.user!.committees;
+    const periodCommittees = [...data.period?.committees, ...data.period?.optionalCommittees];
 
-        if (data.period) {
-          const userCommittees = session!.user!.committees;
-          const periodCommittees = data.period.committees;
+    const matchingCommittees = periodCommittees.filter(
+      (committee: string) =>
+        userCommittees?.includes(committee.toLowerCase())
+    );
+    setCommittees(matchingCommittees);
 
-          if (data.period.optionalCommittees != null) {
-            periodCommittees.push(...data.period.optionalCommittees);
-          }
+  }, [data, session])
 
-          const filteredCommittees = periodCommittees.filter(
-            (committee: string) =>
-              userCommittees?.includes(committee.toLowerCase())
-          );
-          setCommittees(filteredCommittees);
-        }
-      } catch (error) {
-        console.error("Failed to fetch interview periods:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchPeriod();
-  }, [periodId, session]);
-
-  if (loading) {
-    return <LoadingPage />;
-  }
+  if (session?.user?.committees?.length === 0) return <NotFound />;
+  if (isLoading) return <LoadingPage />;
+  if (isError) return <ErrorPage />;
 
   return (
-    <div className="flex flex-col px-5 pt-5 items-center gap-8">
+    <div className="flex flex-col items-center gap-8 px-5">
       <h2 className="mt-5 mb-6 text-3xl font-bold text-center">Velg komite</h2>
       {committees?.map((committee) =>
         CommitteeCard({

--- a/pages/committee/[period-id]/index.tsx
+++ b/pages/committee/[period-id]/index.tsx
@@ -13,7 +13,7 @@ const ChooseCommittee = () => {
   const router = useRouter();
   const periodId = router.query["period-id"];
 
-  const [committees, setCommittees] = useState<string[]>();
+  const [committees, setCommittees] = useState<string[] | null>(null);
 
   const { data, isError, isLoading } = useQuery({
     queryKey: ['periods', periodId],


### PR DESCRIPTION
Installerte tanstack query for å gjøre kode for fetching mer effektiv og leselig.

Kun refaktorert noen steder nå, tenker å få gjort alt etterhvert.

Men tanstack kan vi også slippe å gjøre mange api kall, siden de alltid blir cacha. Så hvis en side skal gjøre samme api-kall som en annen, henter den bare fra cache.