### PR TITLE
Fix illustration not showing in safari

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,7 +45,7 @@ const Home = () => {
             <Button title="Komiteer" color="white" href="/committees" />
           </div>
         </div>
-        <div className="hidden lg:mt-0 lg:col-span-5 lg:flex">
+        <div className="hidden lg:mt-0 lg:col-span-5 lg:block">
           <FestivitiesIllustration className={""} />
         </div>
       </div>


### PR DESCRIPTION
The page turned out super nice, good job!

The nice svg illustration on the front page does not show up on safari, but does in chrome.

I think it's because the svg does not have a set width, so in safari the flex just shrinks it to 0. https://stackoverflow.com/questions/46922999/inline-svg-disappears-with-flexbox

This just uses display block instead.