### PR TITLE
Navbar fixes

### DIFF
--- a/components/DropdownMenu.tsx
+++ b/components/DropdownMenu.tsx
@@ -31,7 +31,7 @@ const DropdownMenu = ({
     <Link href={path} passHref>
       <button
         onClick={toggleDropdown}
-        className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+        className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
       >
         {label}
       </button>
@@ -54,7 +54,7 @@ const DropdownMenu = ({
 
   return (
     <div
-      className="absolute right-0 z-10 w-48 py-2 mt-2 text-sm text-gray-700 bg-white border border-gray-200 rounded-lg shadow-xl cursor-pointer dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+      className="absolute right-0 z-10 min-w-48 py-2 mt-2 text-sm text-gray-700 bg-white border border-gray-200 rounded-lg shadow-xl cursor-pointer dark:bg-gray-800 dark:border-gray-600 dark:text-white"
       ref={menuRef}
     >
       {!session?.user ? (
@@ -86,7 +86,7 @@ const DropdownMenu = ({
               handleLogout();
               toggleDropdown();
             }}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
           >
             Logg ut
           </button>

--- a/components/DropdownMenu.tsx
+++ b/components/DropdownMenu.tsx
@@ -70,8 +70,9 @@ const DropdownMenu = ({
       ) : (
         <>
           <div className="px-4 py-2 cursor-default">
-            Logget inn som{" "}
-            <span className="font-medium">{session?.user.name}</span>
+            Logget inn som
+            <br />
+            <b>{session?.user.name}</b>
           </div>
           <RenderLink path="/" label="Hjem" />
           {session?.user.role === "admin" && (

--- a/components/DropdownMenu.tsx
+++ b/components/DropdownMenu.tsx
@@ -69,7 +69,7 @@ const DropdownMenu = ({
         </>
       ) : (
         <>
-          <div className="px-4 pb-2 pt-1 cursor-default border-b">
+          <div className="px-4 pb-2 pt-1 cursor-default border-b dark:border-gray-600">
             <div>Logget inn som</div>
             <b>{session?.user.name}</b>
           </div>

--- a/components/DropdownMenu.tsx
+++ b/components/DropdownMenu.tsx
@@ -59,19 +59,18 @@ const DropdownMenu = ({
     >
       {!session?.user ? (
         <>
-          <ThemeToggle />
           <button
             onClick={handleLogin}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
           >
             Logg inn
           </button>
+          <ThemeToggle />
         </>
       ) : (
         <>
-          <div className="px-4 py-2 cursor-default">
-            Logget inn som
-            <br />
+          <div className="px-4 pb-2 pt-1 cursor-default border-b">
+            <div>Logget inn som</div>
             <b>{session?.user.name}</b>
           </div>
           <RenderLink path="/" label="Hjem" />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -92,14 +92,23 @@ const Navbar = () => {
         </div>
       </div>
       <div className="relative lg:hidden flex justify-between items-center px-5 py-5">
-        <Image
-          src={smallOnlineLogoSrc}
-          width={50}
-          height={30 * 1.5}
-          alt="Online logo"
-          className="transition-all cursor-pointer hover:opacity-60"
-          onClick={() => router.push("/")}
-        />
+        <Link href="/" passHref aria-label="Online logo">
+          <Image
+            src={smallOnlineLogoSrc}
+            width={50}
+            height={30 * 1.5}
+            alt="Online logo"
+            className="sm:hidden transition-all cursor-pointer hover:opacity-60"
+          />
+          <Image
+            src={onlineLogoSrc}
+            width={100 * 1.5}
+            height={30 * 1.5}
+            priority
+            alt="Online logo"
+            className="hidden sm:block transition-all cursor-pointer hover:opacity-60"
+          />
+        </Link>
         <div className="relative">
           <button onClick={toggleDropdown} className="flex justify-end">
             <Bars3Icon

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -31,8 +31,8 @@ const Navbar = () => {
     theme === "dark" ? "/Online_hvit.svg" : "/Online_bla.svg";
 
   return (
-    <div>
-      <div className="hidden lg:flex justify-between w-full px-5 py-5 sm:items-center border-b-[1px] border-gray-300 dark:border-0 bg-zinc-50 dark:bg-gray-800">
+    <div className="border-b-[1px] border-gray-300 dark:border-0 bg-zinc-50 dark:bg-gray-800">
+      <div className="hidden lg:flex justify-between w-full px-5 py-5 sm:items-center">
         <Link href="/" passHref aria-label="Online logo">
           <Image
             src={onlineLogoSrc}
@@ -91,7 +91,7 @@ const Navbar = () => {
           <ThemeToggle />
         </div>
       </div>
-      <div className="relative lg:hidden flex justify-between items-center px-5 py-5 border-b-[1px] border-gray-200 dark:border-gray-600">
+      <div className="relative lg:hidden flex justify-between items-center px-5 py-5">
         <Image
           src={smallOnlineLogoSrc}
           width={50}

--- a/components/theme/ThemeToggle.tsx
+++ b/components/theme/ThemeToggle.tsx
@@ -33,7 +33,7 @@ const ThemeToggle = () => {
       </div>
       <div className="md:hidden">
         <button
-          className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+          className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
           onClick={toggleTheme}
         >
           {theme === "dark" ? <p>Light Mode</p> : <p>Dark Mode</p>}

--- a/components/theme/ThemeToggle.tsx
+++ b/components/theme/ThemeToggle.tsx
@@ -31,7 +31,7 @@ const ThemeToggle = () => {
           </div>
         </button>
       </div>
-      <div className="md:hidden">
+      <div className="lg:hidden">
         <button
           className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
           onClick={toggleTheme}


### PR DESCRIPTION
NB: Based on #342, so merge that first.

- Fixed bug where theme-toggle was hidden between 770 and 1020px
- Fixed width of dropdown elements
- Using same colors on navbar for all screen widths
- Changed media-query for online-logo in navbar, to show the full logo longer
- In navbar dropdown, place the usename on seperate line in bold